### PR TITLE
Add a "reveal votes" button

### DIFF
--- a/pub/index.html
+++ b/pub/index.html
@@ -16,7 +16,7 @@
             <div class="logo">Planning Poker</div>
             <div class="socketPreloader" data-bind="visible: socketPreloaderVisible">Connecting to server...</div>
             <div class="login-form" data-bind="visible: !socketPreloaderVisible()">
-                <input type="text" class="username --with-shadow" placeholder="your username" 
+                <input type="text" class="username --with-shadow" placeholder="your username"
                     data-bind="value: userName, css: { loading: userNameLoaderVisible }, attr: { disabled: userNameLoaderVisible }"/>
                 <button class="--with-shadow" data-bind="click: onCreateRoomClick, attr: { disabled: userNameLoaderVisible }, visible: !joinRoomName()">create new room</button>
                 <button class="--with-shadow" data-bind="click: onEnterClick, attr: { disabled: userNameLoaderVisible }, text: joinRoomText()">join existing</button>
@@ -27,6 +27,7 @@
             <div class="roomInfo">
                 <div class="btns">
                     <button class="--with-shadow" data-bind="click: resetRoom">Reset All Votes</button>
+                    <button class="--with-shadow" data-bind="click: revealVotes">Reveal Votes</button>
                 </div>
                 <div class="info">
                     Hello <span class="userName" data-bind="text: userName()"></span>, you're in room
@@ -37,7 +38,7 @@
                 <div class="vote card" tabindex="0" data-bind="text: $data, click: $parent.onVoteCardClick"></div>
             </div>
             <div class="users area" data-bind="foreach: users">
-                <div class="user card" data-bind="css: { voted: $data.vote() !== undefined , flipped: $parent.allVoted()}">
+                <div class="user card" data-bind="css: { voted: $data.vote() !== undefined , flipped: $parent.allVoted() || $parent.isRevealed() }">
                     <div class="front">
                         <div class="vote" data-bind="text: $data.vote() !== undefined ? +$data.vote() : '?'"></div>
                     </div>

--- a/pub/index.html
+++ b/pub/index.html
@@ -27,7 +27,7 @@
             <div class="roomInfo">
                 <div class="btns">
                     <button class="--with-shadow" data-bind="click: resetRoom">Reset All Votes</button>
-                    <button class="--with-shadow" data-bind="click: revealVotes">Reveal Votes</button>
+                    <button class="--with-shadow" data-bind="click: revealVotes, disable: isRevealed">Reveal Votes</button>
                 </div>
                 <div class="info">
                     Hello <span class="userName" data-bind="text: userName()"></span>, you're in room
@@ -38,7 +38,7 @@
                 <div class="vote card" tabindex="0" data-bind="text: $data, click: $parent.onVoteCardClick"></div>
             </div>
             <div class="users area" data-bind="foreach: users">
-                <div class="user card" data-bind="css: { voted: $data.vote() !== undefined , flipped: $parent.allVoted() || $parent.isRevealed() }">
+                <div class="user card" data-bind="css: { voted: $data.vote() !== undefined , flipped: $parent.isRevealed() }">
                     <div class="front">
                         <div class="vote" data-bind="text: $data.vote() !== undefined ? +$data.vote() : '?'"></div>
                     </div>

--- a/pub/poker.css
+++ b/pub/poker.css
@@ -44,9 +44,15 @@ button {
     box-shadow: 2px 2px 0 2px rgba(0, 0, 0, 0.5);
 }
 
-button:active {
+button:active:enabled {
     transform: translate(2px, 2px);
     box-shadow: unset;
+}
+
+button:disabled {
+    background-color: #46a793;
+    color: #ddd;
+    cursor: not-allowed;
 }
 
 body {

--- a/pub/poker.js
+++ b/pub/poker.js
@@ -27,11 +27,20 @@ var _vm = function() {
             }
         });
 
-        if (ret) {
-            this.addRandomCardAngles();
-        }
         return ret && !this.isResetting();
     }, this);
+
+    this.allVoted.subscribe((newAllVotedValue) => {
+        if (newAllVotedValue) {
+            this.isRevealed(true);
+        }
+    });
+
+    this.isRevealed.subscribe((newIsRevealedValue) => {
+        if (newIsRevealedValue) {
+            this.addRandomCardAngles();
+        }
+    });
 
     this.userName = ko.observable();
     this.userId = ko.observable();
@@ -136,7 +145,7 @@ var _vm = function() {
 
         this.socket.on('reset', () => {
             // don't delay if all votes aren't tallied
-            const timeoutLength = this.allVoted() || this.isRevealed() ? 500 : 0;
+            const timeoutLength = this.isRevealed() ? 500 : 0;
 
             if (!!this._reset) {
                 clearTimeout(this._reset);


### PR DESCRIPTION
This PR adds in a "reveal votes" button, shown within planning poker rooms. Pressing on the button will reveal all votes, even if not all participants have submitted their votes.

One pain point our team has had is when not everyone in the room has voted, but the team still wanted to reveal the votes. For example, when someone steps away from their machine before submitting a vote, the rest of the group has to wait until they return and vote before the votes can be shown. This button gives the option to reveal all votes whenever the room is ready for them to be revealed, regardless of the status of the current votes.


https://user-images.githubusercontent.com/25872132/208321891-df3b0d3f-47b6-44e2-9042-3ead3fc0f983.mp4

